### PR TITLE
Add Auth extension and backend with PIN handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+# Copyright (C) Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Install rust
+      run: rustup show
+    - name: Install reuse
+      run: sudo apt-get install --yes reuse
+    - name: Execute checks
+      run: make ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Copyright (C) Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+/target
+Cargo.lock
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+# Copyright (C) Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+[package]
+name = "trussed-auth"
+version = "0.1.0"
+authors = ["Nitrokey GmbH <info@nitrokey.com>"]
+edition = "2021"
+repository = "https://github.com/trussed-dev/trussed-auth"
+license = "Apache-2.0 OR MIT"
+description = "Authentication extension and backend for Trussed"
+
+[dependencies]
+serde = { version = "1", default-features = false }
+sha2 = { version = "0.10.6", default-features = false }
+subtle = { version = "2.4.1", default-features = false }
+trussed = { git = "https://github.com/trussed-dev/trussed", rev = "1c55b3b2dd6a9e1cfc55758635baf0d0bbf387d1", features = ["serde-extensions"] }
+
+[dev-dependencies]
+rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
+trussed = { git = "https://github.com/trussed-dev/trussed", rev = "1c55b3b2dd6a9e1cfc55758635baf0d0bbf387d1", features = ["serde-extensions", "virt"] }

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Copyright (C) Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+.PHONY: check
+check:
+	RUSTLFAGS='-Dwarnings' cargo check --all-features --all-targets
+
+.PHONY: lint
+lint:
+	cargo clippy --all-features --all-targets -- --deny warnings
+	cargo fmt -- --check
+	RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps
+	reuse lint
+
+.PHONY: test
+test:
+	cargo test --all-features
+
+.PHONY: ci
+ci: check lint test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+<!--
+Copyright (C) Nitrokey GmbH
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# trussed-auth
+
+`trussed-auth` is an extension and custom backend for [Trussed][] that provides
+basic PIN handling.
+
+[Trussed]: https://github.com/trussed-dev/trussed
+
+## License
+
+This project is dual-licensed under the [Apache-2.0][] and [MIT][] licenses.
+Configuration files and examples are licensed under the [CC0 1.0
+license][CC0-1.0].  For more information, see the license header in each file.
+You can find a copy of the license texts in the [`LICENSES`](./LICENSES)
+directory.
+
+[Apache-2.0]: https://opensource.org/licenses/Apache-2.0
+[MIT]: https://opensource.org/licenses/MIT
+[CC0-1.0]: https://creativecommons.org/publicdomain/zero/1.0/
+
+This project complies with [version 3.0 of the REUSE specification][reuse].
+
+[reuse]: https://reuse.software/practices/3.0/

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,112 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+mod data;
+
+use trussed::{
+    backend::Backend,
+    error::Result,
+    platform::Platform,
+    serde_extensions::ExtensionImpl,
+    service::ServiceResources,
+    store::filestore::Filestore,
+    types::{CoreContext, Location, PathBuf},
+};
+
+use crate::{
+    extension::{reply, AuthExtension, AuthReply, AuthRequest},
+    PIN_PATH,
+};
+use data::PinData;
+
+/// A basic implementation of the [`AuthExtension`][].
+///
+/// This implementation stores PINs together with their retry counters on the filesystem.  PINs are
+/// hashed with SHA-256 using a salt that is generated per PIN.
+#[derive(Clone, Debug)]
+pub struct AuthBackend {
+    location: Location,
+}
+
+impl AuthBackend {
+    /// Creates a new `AuthBackend` using the given storage location for the PINs.
+    pub fn new(location: Location) -> Self {
+        Self { location }
+    }
+}
+
+impl<P: Platform> Backend<P> for AuthBackend {
+    type Context = ();
+}
+
+impl<P: Platform> ExtensionImpl<AuthExtension, P> for AuthBackend {
+    fn extension_request(
+        &mut self,
+        core_ctx: &mut CoreContext,
+        _ctx: &mut (),
+        request: &AuthRequest,
+        resources: &mut ServiceResources<P>,
+    ) -> Result<AuthReply> {
+        let fs = &mut resources.filestore(core_ctx);
+        match request {
+            AuthRequest::HasPin(request) => {
+                let has_pin = fs.exists(&request.id.path(), self.location);
+                Ok(reply::HasPin { has_pin }.into())
+            }
+            AuthRequest::CheckPin(request) => {
+                let success = PinData::load(fs, self.location, request.id)?.write(
+                    fs,
+                    self.location,
+                    |data| data.check_pin(&request.pin),
+                )?;
+                Ok(reply::CheckPin { success }.into())
+            }
+            AuthRequest::SetPin(request) => {
+                let mut rng = resources.rng().map_err(|_| Error::RngFailed)?;
+                PinData::new(request.id, &request.pin, request.retries, &mut rng)
+                    .save(fs, self.location)?;
+                Ok(reply::SetPin.into())
+            }
+            AuthRequest::DeletePin(request) => {
+                let path = request.id.path();
+                if fs.exists(&path, self.location) {
+                    fs.remove_file(&request.id.path(), self.location)
+                        .map_err(|_| Error::WriteFailed)?;
+                }
+                Ok(reply::DeletePin.into())
+            }
+            AuthRequest::DeleteAllPins(_) => {
+                fs.remove_dir_all(&PathBuf::from(PIN_PATH), self.location)
+                    .map_err(|_| Error::WriteFailed)?;
+                Ok(reply::DeleteAllPins.into())
+            }
+            AuthRequest::PinRetries(request) => {
+                let retries = PinData::load(fs, self.location, request.id)?.retries_left();
+                Ok(reply::PinRetries { retries }.into())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Error {
+    NotFound,
+    RngFailed,
+    ReadFailed,
+    WriteFailed,
+    DeserializationFailed,
+    SerializationFailed,
+}
+
+impl From<Error> for trussed::error::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::NotFound => Self::NoSuchKey,
+            Error::RngFailed => Self::EntropyMalfunction,
+            Error::ReadFailed => Self::FilesystemReadFailure,
+            Error::WriteFailed => Self::FilesystemWriteFailure,
+            Error::DeserializationFailed => Self::ImplementationError,
+            Error::SerializationFailed => Self::ImplementationError,
+        }
+    }
+}

--- a/src/backend/data.rs
+++ b/src/backend/data.rs
@@ -1,0 +1,200 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use core::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
+use trussed::{
+    platform::{CryptoRng, RngCore},
+    store::filestore::Filestore,
+    types::Location,
+};
+
+use super::Error;
+use crate::{Pin, PinId, MAX_PIN_LENGTH};
+
+const SIZE: usize = 256;
+const SALT_LEN: usize = 16;
+const HASH_LEN: usize = 32;
+
+type Salt = [u8; SALT_LEN];
+type Hash = [u8; HASH_LEN];
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct PinData {
+    #[serde(skip)]
+    id: PinId,
+    retries: Option<Retries>,
+    salt: Salt,
+    hash: Hash,
+}
+
+impl PinData {
+    pub fn new<R>(id: PinId, pin: &Pin, retries: Option<u8>, rng: &mut R) -> Self
+    where
+        R: CryptoRng + RngCore,
+    {
+        let mut salt = Salt::default();
+        rng.fill_bytes(&mut salt);
+        let hash = hash(id, pin, &salt);
+        Self {
+            id,
+            retries: retries.map(From::from),
+            salt,
+            hash,
+        }
+    }
+
+    pub fn load<S: Filestore>(fs: &mut S, location: Location, id: PinId) -> Result<Self, Error> {
+        let path = id.path();
+        if !fs.exists(&path, location) {
+            return Err(Error::NotFound);
+        }
+        let data = fs
+            .read::<SIZE>(&path, location)
+            .map_err(|_| Error::ReadFailed)?;
+        let mut data: Self =
+            trussed::cbor_deserialize(&data).map_err(|_| Error::DeserializationFailed)?;
+        data.id = id;
+        Ok(data)
+    }
+
+    pub fn save<S: Filestore>(&self, fs: &mut S, location: Location) -> Result<(), Error> {
+        let data = trussed::cbor_serialize_bytes::<_, SIZE>(self)
+            .map_err(|_| Error::SerializationFailed)?;
+        fs.write(&self.id.path(), location, &data)
+            .map_err(|_| Error::WriteFailed)
+    }
+
+    pub fn retries_left(&self) -> Option<u8> {
+        self.retries.map(|retries| retries.left)
+    }
+
+    pub fn is_blocked(&self) -> bool {
+        if let Some(retries) = self.retries {
+            retries.left == 0
+        } else {
+            false
+        }
+    }
+
+    pub fn write<S, F, R>(&mut self, fs: &mut S, location: Location, f: F) -> Result<R, Error>
+    where
+        S: Filestore,
+        F: Fn(&mut PinDataMut<'_>) -> R,
+    {
+        let mut data = PinDataMut::new(self);
+        let result = f(&mut data);
+        if data.modified {
+            self.save(fs, location)?;
+        }
+        Ok(result)
+    }
+}
+
+pub(crate) struct PinDataMut<'a> {
+    data: &'a mut PinData,
+    modified: bool,
+}
+
+impl<'a> PinDataMut<'a> {
+    fn new(data: &'a mut PinData) -> Self {
+        Self {
+            data,
+            modified: false,
+        }
+    }
+
+    pub fn check_pin(&mut self, pin: &Pin) -> bool {
+        if self.is_blocked() {
+            return false;
+        }
+        let success = hash(self.id, pin, &self.salt).ct_eq(&self.hash).into();
+        if let Some(retries) = &mut self.data.retries {
+            if success {
+                if retries.reset() {
+                    self.modified = true;
+                }
+            } else {
+                retries.decrement();
+                self.modified = true;
+            }
+        }
+        success
+    }
+}
+
+impl Deref for PinDataMut<'_> {
+    type Target = PinData;
+
+    fn deref(&self) -> &Self::Target {
+        self.data
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+struct Retries {
+    max: u8,
+    left: u8,
+}
+
+impl Retries {
+    fn decrement(&mut self) {
+        self.left = self.left.saturating_sub(1);
+    }
+
+    fn reset(&mut self) -> bool {
+        if self.left == self.max {
+            false
+        } else {
+            self.left = self.max;
+            true
+        }
+    }
+}
+
+impl From<u8> for Retries {
+    fn from(retries: u8) -> Self {
+        Self {
+            max: retries,
+            left: retries,
+        }
+    }
+}
+
+fn hash(id: PinId, pin: &Pin, salt: &Salt) -> Hash {
+    let mut digest = Sha256::new();
+    digest.update([u8::from(id)]);
+    digest.update([pin_len(pin)]);
+    digest.update(pin);
+    digest.update(salt);
+    digest.finalize().into()
+}
+
+fn pin_len(pin: &Pin) -> u8 {
+    const _: () = assert!(MAX_PIN_LENGTH <= u8::MAX as usize);
+    pin.len() as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_data_size() {
+        let data = PinData {
+            id: PinId::from(u8::MAX),
+            retries: Some(Retries {
+                max: u8::MAX,
+                left: u8::MAX,
+            }),
+            salt: [u8::MAX; SALT_LEN],
+            hash: [u8::MAX; HASH_LEN],
+        };
+        let serialized = trussed::cbor_serialize_bytes::<_, 1024>(&data).unwrap();
+        assert!(serialized.len() <= SIZE);
+    }
+}

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,114 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+#[allow(missing_docs)]
+pub mod reply;
+#[allow(missing_docs)]
+pub mod request;
+
+use serde::{Deserialize, Serialize};
+use trussed::serde_extensions::{Extension, ExtensionClient, ExtensionResult};
+
+use crate::{Pin, PinId};
+
+/// A result returned by [`AuthClient`][].
+pub type AuthResult<'a, R, C> = ExtensionResult<'a, AuthExtension, R, C>;
+
+/// An extension that provides basic PIN handling.
+///
+/// See [`AuthClient`][] for the requests provided by the extension.
+#[derive(Debug, Default)]
+pub struct AuthExtension;
+
+impl Extension for AuthExtension {
+    type Request = AuthRequest;
+    type Reply = AuthReply;
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
+pub enum AuthRequest {
+    HasPin(request::HasPin),
+    CheckPin(request::CheckPin),
+    SetPin(request::SetPin),
+    DeletePin(request::DeletePin),
+    DeleteAllPins(request::DeleteAllPins),
+    PinRetries(request::PinRetries),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
+pub enum AuthReply {
+    HasPin(reply::HasPin),
+    CheckPin(reply::CheckPin),
+    SetPin(reply::SetPin),
+    DeletePin(reply::DeletePin),
+    DeleteAllPins(reply::DeleteAllPins),
+    PinRetries(reply::PinRetries),
+}
+
+/// Provides access to the [`AuthExtension`][].
+///
+/// The extension manages PINs identified by a [`PinId`][] within the namespace of this client.
+/// PINs can have a retry counter.  If a retry counter is configured when setting a PIN, it is
+/// decremented on every failed authentication attempt.  If the counter reaches zero, all further
+/// authentication attempts fail until the PIN is reset.
+///
+/// The extension does not enforce any constraints on the PINs (except for the maximum length, see
+/// [`MAX_PIN_LENGTH`][]).  Even empty PINs can be used.  Also, there is no authentication required
+/// to set, reset or delete a PIN.  It is up to the application to enforce any policies and
+/// constraints.
+///
+/// [`MAX_PIN_LENGTH`]: `crate::MAX_PIN_LENGTH`
+pub trait AuthClient: ExtensionClient<AuthExtension> {
+    /// Returns true if the PIN is set.
+    fn has_pin<I: Into<PinId>>(&mut self, id: I) -> AuthResult<'_, reply::HasPin, Self> {
+        self.extension(request::HasPin { id: id.into() })
+    }
+
+    /// Returns true if the provided PIN is correct and not blocked.
+    ///
+    /// If the PIN is not correct and a retry counter is configured, the counter is decremented.
+    /// Once it reaches zero, authentication attempts for that PIN fail.  If the PIN with the given
+    /// ID is not set, an error is returned.
+    fn check_pin<I>(&mut self, id: I, pin: Pin) -> AuthResult<'_, reply::CheckPin, Self>
+    where
+        I: Into<PinId>,
+    {
+        self.extension(request::CheckPin { id: id.into(), pin })
+    }
+
+    /// Sets the given PIN and resets its retry counter.
+    ///
+    /// If the retry counter is `None`, the number of retries is not limited and the PIN will never
+    /// be blocked.
+    fn set_pin<I: Into<PinId>>(
+        &mut self,
+        id: I,
+        pin: Pin,
+        retries: Option<u8>,
+    ) -> AuthResult<'_, reply::SetPin, Self> {
+        self.extension(request::SetPin {
+            id: id.into(),
+            pin,
+            retries,
+        })
+    }
+
+    /// Deletes the given PIN (if it exists).
+    fn delete_pin<I: Into<PinId>>(&mut self, id: I) -> AuthResult<'_, reply::DeletePin, Self> {
+        self.extension(request::DeletePin { id: id.into() })
+    }
+
+    /// Deletes all PINs for this client.
+    fn delete_all_pins(&mut self) -> AuthResult<'_, reply::DeleteAllPins, Self> {
+        self.extension(request::DeleteAllPins)
+    }
+
+    /// Returns the remaining retries for the given PIN.
+    fn pin_retries<I: Into<PinId>>(&mut self, id: I) -> AuthResult<'_, reply::PinRetries, Self> {
+        self.extension(request::PinRetries { id: id.into() })
+    }
+}
+
+impl<C: ExtensionClient<AuthExtension>> AuthClient for C {}

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -1,0 +1,136 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use serde::{Deserialize, Serialize};
+use trussed::error::{Error, Result};
+
+use super::AuthReply;
+
+#[derive(Debug, Deserialize, Serialize)]
+#[must_use]
+pub struct HasPin {
+    pub has_pin: bool,
+}
+
+impl From<HasPin> for AuthReply {
+    fn from(reply: HasPin) -> Self {
+        Self::HasPin(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for HasPin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::HasPin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[must_use]
+pub struct CheckPin {
+    pub success: bool,
+}
+
+impl From<CheckPin> for AuthReply {
+    fn from(reply: CheckPin) -> Self {
+        Self::CheckPin(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for CheckPin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::CheckPin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetPin;
+
+impl From<SetPin> for AuthReply {
+    fn from(reply: SetPin) -> Self {
+        Self::SetPin(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for SetPin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::SetPin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeletePin;
+
+impl From<DeletePin> for AuthReply {
+    fn from(reply: DeletePin) -> Self {
+        Self::DeletePin(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for DeletePin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::DeletePin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteAllPins;
+
+impl From<DeleteAllPins> for AuthReply {
+    fn from(reply: DeleteAllPins) -> Self {
+        Self::DeleteAllPins(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for DeleteAllPins {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::DeleteAllPins(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[must_use]
+pub struct PinRetries {
+    pub retries: Option<u8>,
+}
+
+impl From<PinRetries> for AuthReply {
+    fn from(reply: PinRetries) -> Self {
+        Self::PinRetries(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for PinRetries {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::PinRetries(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -1,0 +1,74 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use serde::{Deserialize, Serialize};
+
+use super::AuthRequest;
+use crate::{Pin, PinId};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HasPin {
+    pub id: PinId,
+}
+
+impl From<HasPin> for AuthRequest {
+    fn from(request: HasPin) -> Self {
+        Self::HasPin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CheckPin {
+    pub id: PinId,
+    pub pin: Pin,
+}
+
+impl From<CheckPin> for AuthRequest {
+    fn from(request: CheckPin) -> Self {
+        Self::CheckPin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetPin {
+    pub id: PinId,
+    pub pin: Pin,
+    pub retries: Option<u8>,
+}
+
+impl From<SetPin> for AuthRequest {
+    fn from(request: SetPin) -> Self {
+        Self::SetPin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeletePin {
+    pub id: PinId,
+}
+
+impl From<DeletePin> for AuthRequest {
+    fn from(request: DeletePin) -> Self {
+        Self::DeletePin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteAllPins;
+
+impl From<DeleteAllPins> for AuthRequest {
+    fn from(request: DeleteAllPins) -> Self {
+        Self::DeleteAllPins(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PinRetries {
+    pub id: PinId,
+}
+
+impl From<PinRetries> for AuthRequest {
+    fn from(request: PinRetries) -> Self {
+        Self::PinRetries(request)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,138 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+#![no_std]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    non_ascii_idents,
+    trivial_casts,
+    unused,
+    unused_qualifications,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
+#![deny(unsafe_code)]
+
+//! A Trussed API extension for authentication and a backend that implements it.
+//!
+//! This crate contains an API extension for [Trussed][], [`AuthExtension`][].  The extension
+//! currently provides basic PIN handling with retry counters.  Applications can access it using
+//! the [`AuthClient`][] trait.
+//!
+//! This crate also contains [`AuthBackend`][], an implementation of the auth extension that stores
+//! PINs in the filesystem.
+//!
+//! # Examples
+//!
+//! ```
+//! use trussed::{Bytes, syscall};
+//! use trussed_auth::{AuthClient, PinId};
+//!
+//! #[repr(u8)]
+//! enum Pin {
+//!     User = 0,
+//! }
+//!
+//! impl From<Pin> for PinId {
+//!     fn from(pin: Pin) -> Self {
+//!         (pin as u8).into()
+//!     }
+//! }
+//!
+//! fn authenticate_user<C: AuthClient>(client: &mut C, pin: Option<&[u8]>) -> bool {
+//!     if !syscall!(client.has_pin(Pin::User)).has_pin {
+//!         // no PIN set
+//!         return true;
+//!     }
+//!     let Some(pin) = pin else {
+//!         // PIN is set but not provided
+//!         return false;
+//!     };
+//!     let Ok(pin) = Bytes::from_slice(pin) else {
+//!         // provided PIN is too long
+//!         return false;
+//!     };
+//!     // check PIN
+//!     syscall!(client.check_pin(Pin::User, pin)).success
+//! }
+//! ```
+//!
+//! [Trussed]: https://docs.rs/trussed
+
+mod backend;
+mod extension;
+
+use serde::{Deserialize, Serialize};
+use trussed::{
+    config::MAX_SHORT_DATA_LENGTH,
+    types::{Bytes, PathBuf},
+};
+
+pub use backend::AuthBackend;
+pub use extension::{
+    reply, request, AuthClient, AuthExtension, AuthReply, AuthRequest, AuthResult,
+};
+
+/// The maximum length of a PIN.
+pub const MAX_PIN_LENGTH: usize = MAX_SHORT_DATA_LENGTH;
+
+/// A PIN.
+pub type Pin = Bytes<MAX_PIN_LENGTH>;
+
+const PIN_PATH: &str = "backend/auth/pin";
+
+/// The ID of a PIN within the namespace of a client.
+///
+/// It is recommended that applications use an enum that implements `Into<PinId>`.
+///
+/// # Examples
+///
+/// ```
+/// use trussed_auth::PinId;
+///
+/// #[repr(u8)]
+/// enum Pin {
+///     User = 0,
+///     Admin = 1,
+///     ResetCode = 2,
+/// }
+///
+/// impl From<Pin> for PinId {
+///     fn from(pin: Pin) -> Self {
+///         (pin as u8).into()
+///     }
+/// }
+/// ```
+#[derive(
+    Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
+)]
+pub struct PinId(u8);
+
+impl PinId {
+    fn path(&self) -> PathBuf {
+        let mut path = PathBuf::from(PIN_PATH);
+        path.push(&PathBuf::from(&self.hex()));
+        path
+    }
+
+    fn hex(&self) -> [u8; 2] {
+        const CHARS: &[u8; 16] = b"0123456789abcdef";
+        [
+            CHARS[usize::from(self.0 >> 4)],
+            CHARS[usize::from(self.0 & 0xf)],
+        ]
+    }
+}
+
+impl From<u8> for PinId {
+    fn from(id: u8) -> Self {
+        Self(id)
+    }
+}
+
+impl From<PinId> for u8 {
+    fn from(id: PinId) -> Self {
+        id.0
+    }
+}

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -1,0 +1,376 @@
+// Copyright (C) Nitrokey GmbH
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+mod dispatch {
+    use trussed::{
+        api::{reply, request, Reply, Request},
+        backend::{Backend as _, BackendId},
+        error::Error,
+        platform::Platform,
+        serde_extensions::{ExtensionDispatch, ExtensionId, ExtensionImpl as _},
+        service::ServiceResources,
+        types::{Context, Location},
+    };
+    use trussed_auth::{AuthBackend, AuthExtension};
+
+    pub const BACKENDS: &[BackendId<Backend>] =
+        &[BackendId::Custom(Backend::Auth), BackendId::Core];
+
+    pub enum Backend {
+        Auth,
+    }
+
+    pub enum Extension {
+        Auth,
+    }
+
+    impl From<Extension> for u8 {
+        fn from(extension: Extension) -> Self {
+            match extension {
+                Extension::Auth => 0,
+            }
+        }
+    }
+
+    impl TryFrom<u8> for Extension {
+        type Error = Error;
+
+        fn try_from(id: u8) -> Result<Self, Self::Error> {
+            match id {
+                0 => Ok(Extension::Auth),
+                _ => Err(Error::InternalError),
+            }
+        }
+    }
+
+    pub struct Dispatch {
+        auth: AuthBackend,
+    }
+
+    impl Dispatch {
+        pub fn new() -> Self {
+            Self {
+                auth: AuthBackend::new(Location::Internal),
+            }
+        }
+    }
+
+    impl<P: Platform> ExtensionDispatch<P> for Dispatch {
+        type BackendId = Backend;
+        type Context = ();
+        type ExtensionId = Extension;
+
+        fn core_request(
+            &mut self,
+            backend: &Self::BackendId,
+            ctx: &mut Context<Self::Context>,
+            request: &Request,
+            resources: &mut ServiceResources<P>,
+        ) -> Result<Reply, Error> {
+            match backend {
+                Backend::Auth => self
+                    .auth
+                    .request(&mut ctx.core, &mut (), request, resources),
+            }
+        }
+
+        fn extension_request(
+            &mut self,
+            backend: &Self::BackendId,
+            extension: &Self::ExtensionId,
+            ctx: &mut Context<Self::Context>,
+            request: &request::SerdeExtension,
+            resources: &mut ServiceResources<P>,
+        ) -> Result<reply::SerdeExtension, Error> {
+            match backend {
+                Backend::Auth => match extension {
+                    Extension::Auth => self.auth.extension_request_serialized(
+                        &mut ctx.core,
+                        &mut (),
+                        request,
+                        resources,
+                    ),
+                },
+            }
+        }
+    }
+
+    impl ExtensionId<AuthExtension> for Dispatch {
+        type Id = Extension;
+
+        const ID: Self::Id = Self::Id::Auth;
+    }
+}
+
+use rand_core::{OsRng, RngCore as _};
+use trussed::{
+    backend::BackendId,
+    client::ClientImplementation,
+    service::Service,
+    syscall, try_syscall,
+    types::Bytes,
+    virt::{self, Ram},
+};
+use trussed_auth::{AuthClient as _, PinId};
+
+use dispatch::{Backend, Dispatch, BACKENDS};
+
+type Platform = virt::Platform<Ram>;
+type Client = ClientImplementation<Service<Platform, Dispatch>, Dispatch>;
+
+enum Pin {
+    User,
+    Admin,
+    Custom,
+}
+
+impl From<Pin> for u8 {
+    fn from(pin: Pin) -> Self {
+        match pin {
+            Pin::User => 0,
+            Pin::Admin => 1,
+            Pin::Custom => 2,
+        }
+    }
+}
+
+impl From<Pin> for PinId {
+    fn from(pin: Pin) -> Self {
+        Self::from(u8::from(pin))
+    }
+}
+
+fn run<F: FnOnce(&mut Client)>(backends: &'static [BackendId<Backend>], f: F) {
+    virt::with_platform(Ram::default(), |platform| {
+        platform.run_client_with_backends("test", Dispatch::new(), backends, |mut client| {
+            f(&mut client)
+        })
+    })
+}
+
+fn random_pin() -> trussed_auth::Pin {
+    let mut pin = Bytes::new();
+    pin.resize_to_capacity();
+    OsRng.fill_bytes(&mut pin);
+    pin
+}
+
+#[test]
+fn basic() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::from_slice(b"12345678").unwrap();
+        let pin2 = Bytes::from_slice(b"123456").unwrap();
+
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(!reply.has_pin);
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(reply.has_pin);
+        let reply = syscall!(client.has_pin(Pin::Admin));
+        assert!(!reply.has_pin);
+
+        let reply = syscall!(client.pin_retries(Pin::User));
+        assert_eq!(reply.retries, None);
+
+        let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
+        assert!(reply.success);
+
+        let reply = syscall!(client.pin_retries(Pin::User));
+        assert_eq!(reply.retries, None);
+
+        let reply = syscall!(client.check_pin(Pin::User, pin2));
+        assert!(!reply.success);
+
+        let result = try_syscall!(client.check_pin(Pin::Admin, pin1.clone()));
+        assert!(result.is_err());
+
+        let reply = syscall!(client.pin_retries(Pin::User));
+        assert_eq!(reply.retries, None);
+
+        syscall!(client.delete_pin(Pin::User));
+
+        let result = try_syscall!(client.check_pin(Pin::User, pin1));
+        assert!(result.is_err());
+
+        let result = try_syscall!(client.pin_retries(Pin::User));
+        assert!(result.is_err());
+    })
+}
+
+#[test]
+fn blocked_pin() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::from_slice(b"12345678").unwrap();
+        let pin2 = Bytes::from_slice(b"123456").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3)));
+
+        let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
+        assert!(reply.success);
+
+        for _ in 0..10 {
+            let reply = syscall!(client.check_pin(Pin::User, pin2.clone()));
+            assert!(!reply.success);
+        }
+
+        let reply = syscall!(client.check_pin(Pin::User, pin1));
+        assert!(!reply.success);
+    })
+}
+
+#[test]
+fn set_blocked_pin() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::from_slice(b"12345678").unwrap();
+        let pin2 = Bytes::from_slice(b"123456").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(1)));
+        let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
+        assert!(reply.success);
+        let reply = syscall!(client.check_pin(Pin::User, pin2.clone()));
+        assert!(!reply.success);
+        let reply = syscall!(client.check_pin(Pin::User, pin1));
+        assert!(!reply.success);
+
+        syscall!(client.set_pin(Pin::User, pin2.clone(), Some(1)));
+        let reply = syscall!(client.check_pin(Pin::User, pin2));
+        assert!(reply.success);
+    })
+}
+
+#[test]
+fn empty_pin() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::new();
+        let pin2 = Bytes::from_slice(b"123456").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(reply.has_pin);
+        let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
+        assert!(reply.success);
+        let reply = syscall!(client.check_pin(Pin::User, pin2));
+        assert!(!reply.success);
+        let reply = syscall!(client.check_pin(Pin::User, pin1));
+        assert!(reply.success);
+    })
+}
+
+#[test]
+fn max_pin_length() {
+    run(BACKENDS, |client| {
+        let pin1 = random_pin();
+        let pin2 = loop {
+            let pin = random_pin();
+            if pin1 != pin {
+                break pin;
+            }
+        };
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        let reply = syscall!(client.check_pin(Pin::User, pin1));
+        assert!(reply.success);
+        let reply = syscall!(client.check_pin(Pin::User, pin2));
+        assert!(!reply.success);
+    })
+}
+
+#[test]
+fn pin_retries() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::from_slice(b"12345678").unwrap();
+        let pin2 = Bytes::from_slice(b"123456").unwrap();
+        let pin3 = Bytes::from_slice(b"654321").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3)));
+        syscall!(client.set_pin(Pin::Admin, pin2.clone(), Some(5)));
+        syscall!(client.set_pin(Pin::Custom, pin3.clone(), None));
+
+        let reply = syscall!(client.pin_retries(Pin::User));
+        assert_eq!(reply.retries, Some(3));
+        let reply = syscall!(client.pin_retries(Pin::Admin));
+        assert_eq!(reply.retries, Some(5));
+        let reply = syscall!(client.pin_retries(Pin::Custom));
+        assert_eq!(reply.retries, None);
+
+        for i in 0..2 {
+            let reply = syscall!(client.check_pin(Pin::User, pin2.clone()));
+            assert!(!reply.success);
+            let reply = syscall!(client.check_pin(Pin::Admin, pin3.clone()));
+            assert!(!reply.success);
+            let reply = syscall!(client.check_pin(Pin::Custom, pin1.clone()));
+            assert!(!reply.success);
+
+            let reply = syscall!(client.pin_retries(Pin::User));
+            assert_eq!(reply.retries, Some(3 - i - 1));
+            let reply = syscall!(client.pin_retries(Pin::Admin));
+            assert_eq!(reply.retries, Some(5 - i - 1));
+            let reply = syscall!(client.pin_retries(Pin::Custom));
+            assert_eq!(reply.retries, None);
+        }
+
+        let reply = syscall!(client.check_pin(Pin::User, pin1));
+        assert!(reply.success);
+        let reply = syscall!(client.check_pin(Pin::Admin, pin2));
+        assert!(reply.success);
+        let reply = syscall!(client.check_pin(Pin::Custom, pin3));
+        assert!(reply.success);
+
+        let reply = syscall!(client.pin_retries(Pin::User));
+        assert_eq!(reply.retries, Some(3));
+        let reply = syscall!(client.pin_retries(Pin::Admin));
+        assert_eq!(reply.retries, Some(5));
+        let reply = syscall!(client.pin_retries(Pin::Custom));
+        assert_eq!(reply.retries, None);
+    })
+}
+
+#[test]
+fn delete_pin() {
+    run(BACKENDS, |client| {
+        let pin = Bytes::from_slice(b"123456").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin.clone(), None));
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(reply.has_pin);
+
+        syscall!(client.delete_pin(Pin::User));
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(!reply.has_pin);
+
+        let result = try_syscall!(client.check_pin(Pin::User, pin));
+        assert!(result.is_err());
+
+        syscall!(client.delete_pin(Pin::User));
+    })
+}
+
+#[test]
+fn delete_all_pins() {
+    run(BACKENDS, |client| {
+        let pin1 = Bytes::from_slice(b"123456").unwrap();
+        let pin2 = Bytes::from_slice(b"12345678").unwrap();
+
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        syscall!(client.set_pin(Pin::Admin, pin2.clone(), None));
+
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(reply.has_pin);
+        let reply = syscall!(client.has_pin(Pin::Admin));
+        assert!(reply.has_pin);
+
+        syscall!(client.delete_all_pins());
+
+        let reply = syscall!(client.has_pin(Pin::User));
+        assert!(!reply.has_pin);
+        let reply = syscall!(client.has_pin(Pin::Admin));
+        assert!(!reply.has_pin);
+
+        let result = try_syscall!(client.check_pin(Pin::User, pin1));
+        assert!(result.is_err());
+        let result = try_syscall!(client.check_pin(Pin::Admin, pin2));
+        assert!(result.is_err());
+    })
+}


### PR DESCRIPTION
This patch implements a basic Auth extension and backend that provides PIN handling.  Policies still have to be enforced by the client.

Fixes https://github.com/trussed-dev/trussed-auth/issues/1

Open tasks:
- [x] Setup repository scaffolding (readme, gitignore, licenses, CI, ...)
- [x] Use upstream Trussed once extension support has landed
- [x] Add tests
  - Basic tests are implemented, more advanced tests missing.
- [x] Add documentation
- [x] API questions
  - [x] should `CheckPin` return an error or `false`?
  - [x] can we change blocked PINs with `SetPin`?
  - [x] what is the maximum PIN length?  `SHORT_DATA_LEN`?
- [ ] Implementation questions
  - [x] Use `zeroize`/`secrecy`/...?
    - Currently, `secrecy` cannot be used with `serde` in no-std environments.
  - [x] proper error types
  - [ ] review of PIN handling
  - [x] how much space do we need for serialization
  - [ ] FS layout
  - [x] replace `scrypt`
    - `scrypt` is too slow for us.  We probably have to use a manual implementation.