### PR TITLE
Add encryption key derivation from PIN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,12 @@ serde = { version = "1", default-features = false }
 serde-byte-array = "0.1.2"
 sha2 = { version = "0.10.6", default-features = false }
 subtle = { version = "2.4.1", default-features = false }
-trussed = { git = "https://github.com/trussed-dev/trussed", rev = "1c55b3b2dd6a9e1cfc55758635baf0d0bbf387d1", features = ["serde-extensions"] }
+trussed = { version = "0.1.0", features = ["serde-extensions"] }
 
 [dev-dependencies]
 rand_core = { version = "0.6.4", default-features = false, features = ["getrandom"] }
-trussed = { git = "https://github.com/trussed-dev/trussed", rev = "1c55b3b2dd6a9e1cfc55758635baf0d0bbf387d1", features = ["serde-extensions", "virt"] }
+trussed = { version = "0.1.0", features = ["serde-extensions", "virt"] }
+
+[patch.crates-io]
+littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
+trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey-5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0 OR MIT"
 description = "Authentication extension and backend for Trussed"
 
 [dependencies]
+chacha20poly1305 = { version = "0.10.1", default-features = false, features = ["reduced-round"] }
 hkdf = "0.12.3"
 hmac = "0.12.1"
 rand_core = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "Apache-2.0 OR MIT"
 description = "Authentication extension and backend for Trussed"
 
 [dependencies]
+hkdf = "0.12.3"
+hmac = "0.12.1"
+rand_core = "0.6.4"
 serde = { version = "1", default-features = false }
 serde-byte-array = "0.1.2"
 sha2 = { version = "0.10.6", default-features = false }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,6 +3,11 @@
 
 mod data;
 
+use core::fmt;
+
+use hkdf::Hkdf;
+use rand_core::{CryptoRng, RngCore};
+use sha2::Sha256;
 use trussed::{
     backend::Backend,
     error::Result,
@@ -11,13 +16,33 @@ use trussed::{
     service::ServiceResources,
     store::filestore::Filestore,
     types::{CoreContext, Location, PathBuf},
+    Bytes,
 };
 
 use crate::{
     extension::{reply, AuthExtension, AuthReply, AuthRequest},
-    PIN_PATH,
+    PIN_PATH, SALT_PATH,
 };
 use data::PinData;
+
+const MAX_HW_KEY_LEN: usize = 64;
+
+#[derive(Clone)]
+enum HardwareKey {
+    None,
+    Raw(Bytes<MAX_HW_KEY_LEN>),
+    Extracted(Hkdf<Sha256>),
+}
+
+impl fmt::Debug for HardwareKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::None => f.debug_tuple("None").finish(),
+            Self::Raw(_) => f.debug_tuple("Raw").field(&"[redacted]").finish(),
+            Self::Extracted(_) => f.debug_tuple("Raw").field(&"[redacted]").finish(),
+        }
+    }
+}
 
 /// A basic implementation of the [`AuthExtension`][].
 ///
@@ -26,24 +51,128 @@ use data::PinData;
 #[derive(Clone, Debug)]
 pub struct AuthBackend {
     location: Location,
+    hw_key: HardwareKey,
 }
 
 impl AuthBackend {
     /// Creates a new `AuthBackend` using the given storage location for the PINs.
     pub fn new(location: Location) -> Self {
-        Self { location }
+        Self {
+            location,
+            hw_key: HardwareKey::None,
+        }
+    }
+    /// Creates a new `AuthBackend` with a given key.
+    ///
+    /// This key is used to strengthen key generation from the pins
+    pub fn with_hw_key(location: Location, hw_key: Bytes<MAX_HW_KEY_LEN>) -> Self {
+        Self {
+            location,
+            hw_key: HardwareKey::Raw(hw_key),
+        }
+    }
+
+    fn get_salt<R: CryptoRng + RngCore>(
+        &self,
+        trussed_filestore: &mut impl Filestore,
+        rng: &mut R,
+    ) -> Result<[u8; 32], Error> {
+        let path = PathBuf::from(SALT_PATH);
+        trussed_filestore
+            .read(&path, self.location)
+            .map(|d: Bytes<32>| (&**d).try_into().unwrap())
+            .or_else(|_| {
+                if trussed_filestore
+                    .metadata(&path, self.location)
+                    .or(Err(Error::ReadFailed))?
+                    .is_some()
+                {
+                    return Err(Error::ReadFailed);
+                }
+                let mut salt = [0; 32];
+                rng.fill_bytes(&mut salt);
+                trussed_filestore
+                    .write(&path, self.location, &salt)
+                    .or(Err(Error::WriteFailed))
+                    .and(Ok(salt))
+            })
+    }
+
+    fn extract<R: CryptoRng + RngCore>(
+        &mut self,
+        trussed_filestore: &mut impl Filestore,
+        ikm: Option<Bytes<MAX_HW_KEY_LEN>>,
+        rng: &mut R,
+    ) -> Result<&Hkdf<Sha256>, Error> {
+        let ikm: &[u8] = ikm.as_deref().map(|i| &**i).unwrap_or(&[]);
+        let salt = self.get_salt(trussed_filestore, rng)?;
+        let kdf = Hkdf::new(Some(&salt), ikm);
+        self.hw_key = HardwareKey::Extracted(kdf);
+        match &self.hw_key {
+            HardwareKey::Extracted(kdf) => Ok(kdf),
+            // hw_key was just set to Extracted
+            _ => unreachable!(),
+        }
+    }
+
+    fn expand(kdf: &Hkdf<Sha256>, client_id: &PathBuf) -> [u8; 32] {
+        let mut out = [0; 32];
+        kdf.expand(client_id.as_ref().as_bytes(), &mut out).unwrap();
+        out
+    }
+
+    fn generate_app_key<R: CryptoRng + RngCore>(
+        &mut self,
+        client_id: PathBuf,
+        trussed_filestore: &mut impl Filestore,
+        rng: &mut R,
+    ) -> Result<[u8; 32], Error> {
+        Ok(match &self.hw_key {
+            HardwareKey::Extracted(okm) => Self::expand(okm, &client_id),
+            HardwareKey::Raw(hw_k) => {
+                let kdf = self.extract(trussed_filestore, Some(hw_k.clone()), rng)?;
+                Self::expand(kdf, &client_id)
+            }
+            HardwareKey::None => {
+                let kdf = self.extract(trussed_filestore, None, rng)?;
+                Self::expand(kdf, &client_id)
+            }
+        })
+    }
+
+    #[allow(unused)]
+    fn get_app_key<R: CryptoRng + RngCore>(
+        &mut self,
+        client_id: PathBuf,
+        trussed_filestore: &mut impl Filestore,
+        ctx: &mut AuthContext,
+        rng: &mut R,
+    ) -> Result<[u8; 32], Error> {
+        if let Some(app_key) = ctx.application_key {
+            return Ok(app_key);
+        }
+
+        let app_key = self.generate_app_key(client_id, trussed_filestore, rng)?;
+        ctx.application_key = Some(app_key);
+        Ok(app_key)
     }
 }
 
+/// Per-client context for [`AuthBackend`][]
+#[derive(Default, Debug)]
+pub struct AuthContext {
+    application_key: Option<[u8; 32]>,
+}
+
 impl<P: Platform> Backend<P> for AuthBackend {
-    type Context = ();
+    type Context = AuthContext;
 }
 
 impl<P: Platform> ExtensionImpl<AuthExtension, P> for AuthBackend {
     fn extension_request(
         &mut self,
         core_ctx: &mut CoreContext,
-        _ctx: &mut (),
+        _ctx: &mut AuthContext,
         request: &AuthRequest,
         resources: &mut ServiceResources<P>,
     ) -> Result<AuthReply> {
@@ -60,6 +189,9 @@ impl<P: Platform> ExtensionImpl<AuthExtension, P> for AuthBackend {
                     |data| data.check_pin(&request.pin),
                 )?;
                 Ok(reply::CheckPin { success }.into())
+            }
+            AuthRequest::GetPinKey(_request) => {
+                todo!()
             }
             AuthRequest::SetPin(request) => {
                 let mut rng = resources.rng().map_err(|_| Error::RngFailed)?;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -165,12 +165,12 @@ pub struct AuthContext {
     application_key: Option<Key>,
 }
 
-impl<P: Platform> Backend<P> for AuthBackend {
+impl Backend for AuthBackend {
     type Context = AuthContext;
 }
 
-impl<P: Platform> ExtensionImpl<AuthExtension, P> for AuthBackend {
-    fn extension_request(
+impl ExtensionImpl<AuthExtension> for AuthBackend {
+    fn extension_request<P: Platform>(
         &mut self,
         core_ctx: &mut CoreContext,
         ctx: &mut AuthContext,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -25,7 +25,8 @@ use crate::{
 };
 use data::{Key, PinData, Salt, SALT_LEN};
 
-const MAX_HW_KEY_LEN: usize = 64;
+/// max accepted length for the hardware initial key material
+pub const MAX_HW_KEY_LEN: usize = 64;
 
 #[derive(Clone)]
 enum HardwareKey {
@@ -81,11 +82,7 @@ impl AuthBackend {
         trussed_filestore
             .read(&path, self.location)
             .or_else(|_| {
-                if trussed_filestore
-                    .metadata(&path, self.location)
-                    .or(Err(Error::ReadFailed))?
-                    .is_some()
-                {
+                if trussed_filestore.exists(&path, self.location) {
                     return Err(Error::ReadFailed);
                 }
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -64,6 +64,7 @@ impl AuthBackend {
             hw_key: HardwareKey::None,
         }
     }
+
     /// Creates a new `AuthBackend` with a given key.
     ///
     /// This key is used to strengthen key generation from the pins

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -32,6 +32,7 @@ pub enum AuthRequest {
     CheckPin(request::CheckPin),
     GetPinKey(request::GetPinKey),
     SetPin(request::SetPin),
+    ChangePin(request::ChangePin),
     DeletePin(request::DeletePin),
     DeleteAllPins(request::DeleteAllPins),
     PinRetries(request::PinRetries),
@@ -44,6 +45,7 @@ pub enum AuthReply {
     CheckPin(reply::CheckPin),
     GetPinKey(reply::GetPinKey),
     SetPin(reply::SetPin),
+    ChangePin(reply::ChangePin),
     DeletePin(reply::DeletePin),
     DeleteAllPins(reply::DeleteAllPins),
     PinRetries(reply::PinRetries),
@@ -109,6 +111,22 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
             pin,
             retries,
             derive_key,
+        })
+    }
+
+    /// Change the given PIN and resets its retry counter.
+    ///
+    /// The key obtained by [`get_pin_key`](AuthClient::get_pin_key) will stay the same
+    fn change_pin<I: Into<PinId>>(
+        &mut self,
+        id: I,
+        old_pin: Pin,
+        new_pin: Pin,
+    ) -> AuthResult<'_, reply::ChangePin, Self> {
+        self.extension(request::ChangePin {
+            id: id.into(),
+            old_pin,
+            new_pin,
         })
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -89,11 +89,13 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
         id: I,
         pin: Pin,
         retries: Option<u8>,
+        derive_key: bool,
     ) -> AuthResult<'_, reply::SetPin, Self> {
         self.extension(request::SetPin {
             id: id.into(),
             pin,
             retries,
+            derive_key,
         })
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -80,6 +80,19 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
         self.extension(request::CheckPin { id: id.into(), pin })
     }
 
+    /// Returns a keyid if the provided PIN is correct and not blocked.
+    ///
+    /// The pin must have been created with `derive_key` set to true.
+    /// If the PIN is not correct and a retry counter is configured, the counter is decremented.
+    /// Once it reaches zero, authentication attempts for that PIN fail.  If the PIN with the given
+    /// ID is not set, an error is returned.
+    fn get_pin_key<I>(&mut self, id: I, pin: Pin) -> AuthResult<'_, reply::GetPinKey, Self>
+    where
+        I: Into<PinId>,
+    {
+        self.extension(request::GetPinKey { id: id.into(), pin })
+    }
+
     /// Sets the given PIN and resets its retry counter.
     ///
     /// If the retry counter is `None`, the number of retries is not limited and the PIN will never

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -30,6 +30,7 @@ impl Extension for AuthExtension {
 pub enum AuthRequest {
     HasPin(request::HasPin),
     CheckPin(request::CheckPin),
+    GetPinKey(request::GetPinKey),
     SetPin(request::SetPin),
     DeletePin(request::DeletePin),
     DeleteAllPins(request::DeleteAllPins),
@@ -41,6 +42,7 @@ pub enum AuthRequest {
 pub enum AuthReply {
     HasPin(reply::HasPin),
     CheckPin(reply::CheckPin),
+    GetPinKey(reply::GetPinKey),
     SetPin(reply::SetPin),
     DeletePin(reply::DeletePin),
     DeleteAllPins(reply::DeleteAllPins),

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -44,6 +44,17 @@ impl From<CheckPin> for AuthReply {
     }
 }
 
+impl TryFrom<AuthReply> for CheckPin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::CheckPin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[must_use]
 pub struct GetPinKey {
@@ -57,12 +68,12 @@ impl From<GetPinKey> for AuthReply {
     }
 }
 
-impl TryFrom<AuthReply> for CheckPin {
+impl TryFrom<AuthReply> for GetPinKey {
     type Error = Error;
 
     fn try_from(reply: AuthReply) -> Result<Self> {
         match reply {
-            AuthReply::CheckPin(reply) => Ok(reply),
+            AuthReply::GetPinKey(reply) => Ok(reply),
             _ => Err(Error::InternalError),
         }
     }

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use serde::{Deserialize, Serialize};
-use trussed::error::{Error, Result};
+use trussed::{
+    error::{Error, Result},
+    types::KeyId,
+};
 
 use super::AuthReply;
 
@@ -38,6 +41,19 @@ pub struct CheckPin {
 impl From<CheckPin> for AuthReply {
     fn from(reply: CheckPin) -> Self {
         Self::CheckPin(reply)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[must_use]
+pub struct GetPinKey {
+    /// None means the check failed
+    pub result: Option<KeyId>,
+}
+
+impl From<GetPinKey> for AuthReply {
+    fn from(reply: GetPinKey) -> Self {
+        Self::GetPinKey(reply)
     }
 }
 

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -100,6 +100,28 @@ impl TryFrom<AuthReply> for SetPin {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ChangePin {
+    pub success: bool,
+}
+
+impl From<ChangePin> for AuthReply {
+    fn from(reply: ChangePin) -> Self {
+        Self::ChangePin(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for ChangePin {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::ChangePin(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeletePin;
 
 impl From<DeletePin> for AuthReply {

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -46,6 +46,8 @@ pub struct SetPin {
     pub id: PinId,
     pub pin: Pin,
     pub retries: Option<u8>,
+    /// If true, the PIN can be used to wrap/unwrap an application key
+    pub derive_key: bool,
 }
 
 impl From<SetPin> for AuthRequest {

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -30,6 +30,18 @@ impl From<CheckPin> for AuthRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct GetPinKey {
+    pub id: PinId,
+    pub pin: Pin,
+}
+
+impl From<GetPinKey> for AuthRequest {
+    fn from(request: GetPinKey) -> Self {
+        Self::GetPinKey(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct SetPin {
     pub id: PinId,
     pub pin: Pin,

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -57,6 +57,19 @@ impl From<SetPin> for AuthRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ChangePin {
+    pub id: PinId,
+    pub old_pin: Pin,
+    pub new_pin: Pin,
+}
+
+impl From<ChangePin> for AuthRequest {
+    fn from(request: ChangePin) -> Self {
+        Self::ChangePin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeletePin {
     pub id: PinId,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use trussed::{
     types::{Bytes, PathBuf},
 };
 
-pub use backend::{AuthBackend, AuthContext};
+pub use backend::{AuthBackend, AuthContext, MAX_HW_KEY_LEN};
 pub use extension::{
     reply, request, AuthClient, AuthExtension, AuthReply, AuthRequest, AuthResult,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use trussed::{
     types::{Bytes, PathBuf},
 };
 
-pub use backend::AuthBackend;
+pub use backend::{AuthBackend, AuthContext};
 pub use extension::{
     reply, request, AuthClient, AuthExtension, AuthReply, AuthRequest, AuthResult,
 };
@@ -81,6 +81,7 @@ pub const MAX_PIN_LENGTH: usize = MAX_SHORT_DATA_LENGTH;
 pub type Pin = Bytes<MAX_PIN_LENGTH>;
 
 const PIN_PATH: &str = "backend-auth/pin";
+const SALT_PATH: &str = "backend-auth/salt";
 
 /// The ID of a PIN within the namespace of a client.
 ///

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -346,11 +346,19 @@ fn pin_key() {
             let mac2 = syscall!(client.sign_hmacsha256(key2, b"Some data")).signature;
             assert_eq!(mac, mac2);
 
-            assert!(!syscall!(client.check_pin(Pin::User, pin2.clone())).success);
-            assert!(!syscall!(client.check_pin(Pin::User, pin2.clone())).success);
-            assert!(!syscall!(client.check_pin(Pin::User, pin2.clone())).success);
+            assert!(syscall!(client.change_pin(Pin::User, pin1.clone(), pin2.clone())).success);
+
+            let key3 = syscall!(client.get_pin_key(Pin::User, pin2.clone()))
+                .result
+                .unwrap();
+            let mac3 = syscall!(client.sign_hmacsha256(key3, b"Some data")).signature;
+            assert_eq!(mac, mac3);
+
             assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
-            assert!(syscall!(client.get_pin_key(Pin::User, pin1.clone()))
+            assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
+            assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
+            assert!(!syscall!(client.check_pin(Pin::User, pin2.clone())).success);
+            assert!(syscall!(client.get_pin_key(Pin::User, pin2.clone()))
                 .result
                 .is_none());
             assert_eq!(syscall!(client.pin_retries(Pin::User)).retries, Some(0));

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -170,7 +170,7 @@ fn basic() {
         let reply = syscall!(client.has_pin(Pin::User));
         assert!(!reply.has_pin);
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None, false));
 
         let reply = syscall!(client.has_pin(Pin::User));
         assert!(reply.has_pin);
@@ -211,7 +211,7 @@ fn blocked_pin() {
         let pin1 = Bytes::from_slice(b"12345678").unwrap();
         let pin2 = Bytes::from_slice(b"123456").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3)));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3), false));
 
         let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
         assert!(reply.success);
@@ -232,7 +232,7 @@ fn set_blocked_pin() {
         let pin1 = Bytes::from_slice(b"12345678").unwrap();
         let pin2 = Bytes::from_slice(b"123456").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(1)));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(1), false));
         let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
         assert!(reply.success);
         let reply = syscall!(client.check_pin(Pin::User, pin2.clone()));
@@ -240,7 +240,7 @@ fn set_blocked_pin() {
         let reply = syscall!(client.check_pin(Pin::User, pin1));
         assert!(!reply.success);
 
-        syscall!(client.set_pin(Pin::User, pin2.clone(), Some(1)));
+        syscall!(client.set_pin(Pin::User, pin2.clone(), Some(1), false));
         let reply = syscall!(client.check_pin(Pin::User, pin2));
         assert!(reply.success);
     })
@@ -252,7 +252,7 @@ fn empty_pin() {
         let pin1 = Bytes::new();
         let pin2 = Bytes::from_slice(b"123456").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None, false));
         let reply = syscall!(client.has_pin(Pin::User));
         assert!(reply.has_pin);
         let reply = syscall!(client.check_pin(Pin::User, pin1.clone()));
@@ -275,7 +275,7 @@ fn max_pin_length() {
             }
         };
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None, false));
         let reply = syscall!(client.check_pin(Pin::User, pin1));
         assert!(reply.success);
         let reply = syscall!(client.check_pin(Pin::User, pin2));
@@ -290,9 +290,9 @@ fn pin_retries() {
         let pin2 = Bytes::from_slice(b"123456").unwrap();
         let pin3 = Bytes::from_slice(b"654321").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3)));
-        syscall!(client.set_pin(Pin::Admin, pin2.clone(), Some(5)));
-        syscall!(client.set_pin(Pin::Custom, pin3.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), Some(3), false));
+        syscall!(client.set_pin(Pin::Admin, pin2.clone(), Some(5), false));
+        syscall!(client.set_pin(Pin::Custom, pin3.clone(), None, false));
 
         let reply = syscall!(client.pin_retries(Pin::User));
         assert_eq!(reply.retries, Some(3));
@@ -338,7 +338,7 @@ fn delete_pin() {
     run(BACKENDS, |client| {
         let pin = Bytes::from_slice(b"123456").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin.clone(), None, false));
         let reply = syscall!(client.has_pin(Pin::User));
         assert!(reply.has_pin);
 
@@ -359,8 +359,8 @@ fn delete_all_pins() {
         let pin1 = Bytes::from_slice(b"123456").unwrap();
         let pin2 = Bytes::from_slice(b"12345678").unwrap();
 
-        syscall!(client.set_pin(Pin::User, pin1.clone(), None));
-        syscall!(client.set_pin(Pin::Admin, pin2.clone(), None));
+        syscall!(client.set_pin(Pin::User, pin1.clone(), None, false));
+        syscall!(client.set_pin(Pin::Admin, pin2.clone(), None, false));
 
         let reply = syscall!(client.has_pin(Pin::User));
         assert!(reply.has_pin);

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -356,9 +356,9 @@ fn pin_key() {
 
             assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
             assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
-            assert!(!syscall!(client.check_pin(Pin::User, pin1.clone())).success);
+            assert!(!syscall!(client.check_pin(Pin::User, pin1)).success);
             assert!(!syscall!(client.check_pin(Pin::User, pin2.clone())).success);
-            assert!(syscall!(client.get_pin_key(Pin::User, pin2.clone()))
+            assert!(syscall!(client.get_pin_key(Pin::User, pin2))
                 .result
                 .is_none());
             assert_eq!(syscall!(client.pin_retries(Pin::User)).retries, Some(0));

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -66,12 +66,12 @@ mod dispatch {
         }
     }
 
-    impl<P: Platform> ExtensionDispatch<P> for Dispatch {
+    impl ExtensionDispatch for Dispatch {
         type BackendId = Backend;
         type Context = DispatchContext;
         type ExtensionId = Extension;
 
-        fn core_request(
+        fn core_request<P: Platform>(
             &mut self,
             backend: &Self::BackendId,
             ctx: &mut Context<Self::Context>,
@@ -86,7 +86,7 @@ mod dispatch {
             }
         }
 
-        fn extension_request(
+        fn extension_request<P: Platform>(
             &mut self,
             backend: &Self::BackendId,
             extension: &Self::ExtensionId,


### PR DESCRIPTION
<del>The test currently fail because of a bug in `cbor-smol` fixed in https://github.com/nickray/cbor-smol/pulls</del>

~The tests now fails because of the littlefs2 lookahead bug fixed in version 0.4~