### PR TITLE
Improve byte array serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "Authentication extension and backend for Trussed"
 
 [dependencies]
 serde = { version = "1", default-features = false }
+serde-byte-array = "0.1.0"
 sha2 = { version = "0.10.6", default-features = false }
 subtle = { version = "2.4.1", default-features = false }
 trussed = { git = "https://github.com/trussed-dev/trussed", rev = "1c55b3b2dd6a9e1cfc55758635baf0d0bbf387d1", features = ["serde-extensions"] }


### PR DESCRIPTION
Per default, byte arrays are serialized inefficiently by serde.

<s>serde_bytes provides workarounds for byte slice serialization but does not support arrays yet.  heapless_bytes improves the serialization for arrays but does not guarantee their length.  Therefore we introduce a helper type, BytesArray, that uses heapless_bytes’ serialization but enforces a constant length.</s>

serde-byte-array provides a wrapper type with a more efficient serialization format.

Fixes https://github.com/trussed-dev/trussed-auth/issues/11