### PR TITLE
Add reset_pin_key

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -284,14 +284,14 @@ impl ExtensionImpl<AuthExtension> for AuthBackend {
                 .save(fs, self.location)?;
                 Ok(reply::SetPin.into())
             }
-            AuthRequest::ResetPinKey(request) => {
+            AuthRequest::SetPinWithKey(request) => {
                 let app_key = self.get_app_key(client_id, trussed_fs, ctx, rng)?;
                 let key_to_wrap =
                     keystore.load_key(Secrecy::Secret, Some(Kind::Symmetric(32)), &request.key)?;
                 let key_to_wrap = (&*key_to_wrap.material)
                     .try_into()
                     .map_err(|_| Error::ReadFailed)?;
-                PinData::reset_given_key(
+                PinData::reset_with_key(
                     request.id,
                     &request.pin,
                     request.retries,
@@ -300,7 +300,7 @@ impl ExtensionImpl<AuthExtension> for AuthBackend {
                     key_to_wrap,
                 )
                 .save(fs, self.location)?;
-                Ok(reply::ResetPinKey.into())
+                Ok(reply::SetPinWithKey.into())
             }
             AuthRequest::DeletePin(request) => {
                 let path = request.id.path();

--- a/src/backend/data.rs
+++ b/src/backend/data.rs
@@ -171,7 +171,7 @@ impl PinData {
         }
     }
 
-    pub fn reset_given_key<R>(
+    pub fn reset_with_key<R>(
         id: PinId,
         pin: &Pin,
         retries: Option<u8>,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -7,7 +7,10 @@ pub mod reply;
 pub mod request;
 
 use serde::{Deserialize, Serialize};
-use trussed::serde_extensions::{Extension, ExtensionClient, ExtensionResult};
+use trussed::{
+    serde_extensions::{Extension, ExtensionClient, ExtensionResult},
+    types::KeyId,
+};
 
 use crate::{Pin, PinId};
 
@@ -32,6 +35,7 @@ pub enum AuthRequest {
     CheckPin(request::CheckPin),
     GetPinKey(request::GetPinKey),
     SetPin(request::SetPin),
+    ResetPinKey(request::ResetPinKey),
     ChangePin(request::ChangePin),
     DeletePin(request::DeletePin),
     DeleteAllPins(request::DeleteAllPins),
@@ -45,6 +49,7 @@ pub enum AuthReply {
     CheckPin(reply::CheckPin),
     GetPinKey(reply::GetPinKey),
     SetPin(reply::SetPin),
+    ResetPinKey(reply::ResetPinKey),
     ChangePin(reply::ChangePin),
     DeletePin(reply::DeletePin),
     DeleteAllPins(reply::DeleteAllPins),
@@ -111,6 +116,25 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
             pin,
             retries,
             derive_key,
+        })
+    }
+
+    /// Reset a pin.
+    ///
+    /// Similar to [`set_pin`](AuthClient::set_pin), but allows the key that the pin will unwrap to be configured.
+    /// This allows for example backing up the key for a pin, to be able to restore it from another source.
+    fn reset_set_pin_key<I: Into<PinId>>(
+        &mut self,
+        id: I,
+        pin: Pin,
+        retries: Option<u8>,
+        key: KeyId,
+    ) -> AuthResult<'_, reply::ResetPinKey, Self> {
+        self.extension(request::ResetPinKey {
+            id: id.into(),
+            pin,
+            retries,
+            key,
         })
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -119,7 +119,7 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
         })
     }
 
-    /// Set a pin, resetting it's retry counter and setting the key to be wrapped
+    /// Set a pin, resetting its retry counter and setting the key to be wrapped
     ///
     /// Similar to [`set_pin`](AuthClient::set_pin), but allows the key that the pin will unwrap to be configured.
     /// Currently only symmetric 256 bit keys are accepted. This method should be used only with keys that were obtained through [`get_pin_key`](AuthClient::get_pin_key)

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -119,9 +119,10 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
         })
     }
 
-    /// Reset a pin.
+    /// Set a pin, resetting it's retry counter and setting the key to be wrapped
     ///
     /// Similar to [`set_pin`](AuthClient::set_pin), but allows the key that the pin will unwrap to be configured.
+    /// Currently only symmetric 256 bit keys are accepted. This method should be used only with keys that were obtained through [`get_pin_key`](AuthClient::get_pin_key)
     /// This allows for example backing up the key for a pin, to be able to restore it from another source.
     fn set_pin_with_key<I: Into<PinId>>(
         &mut self,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -35,7 +35,7 @@ pub enum AuthRequest {
     CheckPin(request::CheckPin),
     GetPinKey(request::GetPinKey),
     SetPin(request::SetPin),
-    ResetPinKey(request::ResetPinKey),
+    SetPinWithKey(request::SetPinWithKey),
     ChangePin(request::ChangePin),
     DeletePin(request::DeletePin),
     DeleteAllPins(request::DeleteAllPins),
@@ -49,7 +49,7 @@ pub enum AuthReply {
     CheckPin(reply::CheckPin),
     GetPinKey(reply::GetPinKey),
     SetPin(reply::SetPin),
-    ResetPinKey(reply::ResetPinKey),
+    SetPinWithKey(reply::SetPinWithKey),
     ChangePin(reply::ChangePin),
     DeletePin(reply::DeletePin),
     DeleteAllPins(reply::DeleteAllPins),
@@ -123,14 +123,14 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
     ///
     /// Similar to [`set_pin`](AuthClient::set_pin), but allows the key that the pin will unwrap to be configured.
     /// This allows for example backing up the key for a pin, to be able to restore it from another source.
-    fn reset_set_pin_key<I: Into<PinId>>(
+    fn set_pin_with_key<I: Into<PinId>>(
         &mut self,
         id: I,
         pin: Pin,
         retries: Option<u8>,
         key: KeyId,
-    ) -> AuthResult<'_, reply::ResetPinKey, Self> {
-        self.extension(request::ResetPinKey {
+    ) -> AuthResult<'_, reply::SetPinWithKey, Self> {
+        self.extension(request::SetPinWithKey {
             id: id.into(),
             pin,
             retries,

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -100,20 +100,20 @@ impl TryFrom<AuthReply> for SetPin {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct ResetPinKey;
+pub struct SetPinWithKey;
 
-impl From<ResetPinKey> for AuthReply {
-    fn from(reply: ResetPinKey) -> Self {
-        Self::ResetPinKey(reply)
+impl From<SetPinWithKey> for AuthReply {
+    fn from(reply: SetPinWithKey) -> Self {
+        Self::SetPinWithKey(reply)
     }
 }
 
-impl TryFrom<AuthReply> for ResetPinKey {
+impl TryFrom<AuthReply> for SetPinWithKey {
     type Error = Error;
 
     fn try_from(reply: AuthReply) -> Result<Self> {
         match reply {
-            AuthReply::ResetPinKey(reply) => Ok(reply),
+            AuthReply::SetPinWithKey(reply) => Ok(reply),
             _ => Err(Error::InternalError),
         }
     }

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -100,6 +100,26 @@ impl TryFrom<AuthReply> for SetPin {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ResetPinKey;
+
+impl From<ResetPinKey> for AuthReply {
+    fn from(reply: ResetPinKey) -> Self {
+        Self::ResetPinKey(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for ResetPinKey {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::ResetPinKey(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ChangePin {
     pub success: bool,
 }

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -47,7 +47,7 @@ pub struct SetPin {
     pub id: PinId,
     pub pin: Pin,
     pub retries: Option<u8>,
-    /// If true, the PIN can be used to wrap/unwrap an application key
+    /// If true, the PIN can be used to wrap/unwrap a PIN key
     pub derive_key: bool,
 }
 
@@ -62,7 +62,7 @@ pub struct ResetPinKey {
     pub id: PinId,
     pub pin: Pin,
     pub retries: Option<u8>,
-    /// If true, the PIN can be used to wrap/unwrap an application key
+    /// This key will be wrapped. It can be obtained again via a `GetPinKey` request
     pub key: KeyId,
 }
 

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use serde::{Deserialize, Serialize};
+use trussed::types::KeyId;
 
 use super::AuthRequest;
 use crate::{Pin, PinId};
@@ -53,6 +54,21 @@ pub struct SetPin {
 impl From<SetPin> for AuthRequest {
     fn from(request: SetPin) -> Self {
         Self::SetPin(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResetPinKey {
+    pub id: PinId,
+    pub pin: Pin,
+    pub retries: Option<u8>,
+    /// If true, the PIN can be used to wrap/unwrap an application key
+    pub key: KeyId,
+}
+
+impl From<ResetPinKey> for AuthRequest {
+    fn from(request: ResetPinKey) -> Self {
+        Self::ResetPinKey(request)
     }
 }
 

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -58,7 +58,7 @@ impl From<SetPin> for AuthRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct ResetPinKey {
+pub struct SetPinWithKey {
     pub id: PinId,
     pub pin: Pin,
     pub retries: Option<u8>,
@@ -66,9 +66,9 @@ pub struct ResetPinKey {
     pub key: KeyId,
 }
 
-impl From<ResetPinKey> for AuthRequest {
-    fn from(request: ResetPinKey) -> Self {
-        Self::ResetPinKey(request)
+impl From<SetPinWithKey> for AuthRequest {
+    fn from(request: SetPinWithKey) -> Self {
+        Self::SetPinWithKey(request)
     }
 }
 

--- a/tests/backend.rs
+++ b/tests/backend.rs
@@ -455,7 +455,7 @@ fn reset_pin_key() {
             assert_eq!(syscall!(client.pin_retries(Pin::User)).retries, Some(3));
             let mac = syscall!(client.sign_hmacsha256(key, b"Some data")).signature;
 
-            syscall!(client.reset_set_pin_key(Pin::User, pin3.clone(), Some(3), key));
+            syscall!(client.set_pin_with_key(Pin::User, pin3.clone(), Some(3), key));
 
             let key2 = syscall!(client.get_pin_key(Pin::User, pin3.clone()))
                 .result


### PR DESCRIPTION
This syscall allows resetting a pin. Unlike `set_pin`, it takes a key as parameter. This key will be returned by future calls to `get_pin_key`. Unlike `change_pin` this doesn't require knowledge of the current value of the PIN.

The goal is to allow resetting a PIN from another source. For example, OpenPGP smartcards need to be able to reset the user pin given an admin pin With this patch, this can be done by using the admin key to wrap the user key.