### PR TITLE
Use CoreContext::new instead of initializing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+- Use `CoreContext::new` to fix compilation with recent Trussed changes.
+
 [Unreleased]: https://github.com/trussed-dev/trussed-auth/compare/v0.2.1...HEAD
 
 ## [0.2.1][] - 2023-04-05

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -212,16 +212,8 @@ impl ExtensionImpl<AuthExtension> for AuthBackend {
         // FIXME: Have a real implementation from trussed
         let mut backend_path = core_ctx.path.clone();
         backend_path.push(&PathBuf::from(BACKEND_DIR));
-        let fs = &mut resources.filestore(&CoreContext {
-            path: backend_path,
-            read_dir_state: None,
-            read_dir_files_state: None,
-        });
-        let global_fs = &mut resources.filestore(&CoreContext {
-            path: PathBuf::from(BACKEND_DIR),
-            read_dir_state: None,
-            read_dir_files_state: None,
-        });
+        let fs = &mut resources.filestore(&CoreContext::new(backend_path));
+        let global_fs = &mut resources.filestore(&CoreContext::new(PathBuf::from(BACKEND_DIR)));
         let rng = &mut resources.rng()?;
         let client_id = core_ctx.path.clone();
         let keystore = &mut resources.keystore(core_ctx)?;


### PR DESCRIPTION
To improve compatibility with upstream Trussed that will mark CoreContext as non-exhaustive in 0.2.0, this patch replaces the CoreContext field initializer with CoreContext::new.