### PR TITLE
Fix application salt path

### DIFF
--- a/src/backend/data.rs
+++ b/src/backend/data.rs
@@ -17,7 +17,7 @@ use trussed::{
 };
 
 use super::Error;
-use crate::{Pin, PinId, BACKEND_DIR, MAX_PIN_LENGTH};
+use crate::{Pin, PinId, MAX_PIN_LENGTH};
 
 pub(crate) const SIZE: usize = 256;
 pub(crate) const CHACHA_TAG_LEN: usize = 16;
@@ -497,10 +497,7 @@ fn pin_len(pin: &Pin) -> u8 {
 fn app_salt_path() -> PathBuf {
     const SALT_PATH: &str = "application_salt";
 
-    let mut path = PathBuf::new();
-    path.push(&PathBuf::from(BACKEND_DIR));
-    path.push(&PathBuf::from(SALT_PATH));
-    path
+    PathBuf::from(SALT_PATH)
 }
 
 pub(crate) fn get_app_salt<S: Filestore, R: CryptoRng + RngCore>(


### PR DESCRIPTION
The path was duplicated because it is added in the filestore and in the salt path string

Fix #30

Now the full data looks like this:

```
[2023-04-26T12:14:34Z ERROR trussed::service] :: PERSISTENT
[2023-04-26T12:14:34Z ERROR trussed::service] p"/backend-auth\0" p(p"/\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/backend-auth/dat\0" p(p"/backend-auth\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/backend-auth/dat/salt\0" p(p"/backend-auth/dat\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test\0" p(p"/\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/backend-auth\0" p(p"/test\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/backend-auth/dat\0" p(p"/test/backend-auth\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/backend-auth/dat/application_salt\0" p(p"/test/backend-auth/dat\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/backend-auth/dat/pin.00\0" p(p"/test/backend-auth/dat\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/backend-auth/dat/pin.01\0" p(p"/test/backend-auth/dat\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/trussed\0" p(p"/\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/trussed/dat\0" p(p"/trussed\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/trussed/dat/rng-state.bin\0" p(p"/trussed/dat\0")
[2023-04-26T12:14:34Z ERROR trussed::service] :: EXTERNAL
[2023-04-26T12:14:34Z ERROR trussed::service] :: VOLATILE
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test\0" p(p"/\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/sec\0" p(p"/test\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/sec/3ad3b5303bc4ba810cd2c5d10b82a86f\0" p(p"/test/sec\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/sec/54e25250a97e867e3113400efeb9415e\0" p(p"/test/sec\0")
[2023-04-26T12:14:34Z ERROR trussed::service] p"/test/sec/ff903393fc9b14982e3ecebba17537e4\0" p(p"/test/sec\0")
```

The salt is in the same directory as the pins.