### PR TITLE
Delete app keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+### Breaking Changes
+
+- Add `delete_app_keys` and `delete_auth_keys` syscalls. ([#33][])
+
+  - `delete_all_pins` now doesn't affect application keys
+  - `reset_app_keys`: delete all application keys. Getting them again after calling this will not yield the same key
+  - `reset_auth_data` combines `delete_all_pins` and `delete_app_keys`
+
+  Applications (trussed-secrets) relying on the old `delete_all_pins` behaviour will need to be fixed.
+
+[#33]: https://github.com/trussed-dev/trussed-auth/pull/33
 [Unreleased]: https://github.com/trussed-dev/trussed-auth/compare/v0.2.2...HEAD
 
 ## [0.2.2][] - 2023-04-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ trussed = { version = "0.1.0", features = ["serde-extensions", "virt"] }
 
 [patch.crates-io]
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-trussed = { git = "https://github.com/sosthene-nitrokey/trussed.git", branch = "remove-dir-all-where" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "676ed8021e8fbd8efafe291c57466708f3d56fb4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ trussed = { version = "0.1.0", features = ["serde-extensions", "virt"] }
 
 [patch.crates-io]
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey-5" }
+trussed = { git = "https://github.com/sosthene-nitrokey/trussed.git", branch = "remove-dir-all-where" }

--- a/src/backend/data.rs
+++ b/src/backend/data.rs
@@ -512,6 +512,17 @@ pub(crate) fn get_app_salt<S: Filestore, R: CryptoRng + RngCore>(
     }
 }
 
+pub(crate) fn delete_app_salt<S: Filestore>(
+    fs: &mut S,
+    location: Location,
+) -> Result<(), trussed::Error> {
+    if fs.exists(&app_salt_path(), location) {
+        fs.remove_file(&app_salt_path(), location)
+    } else {
+        Ok(())
+    }
+}
+
 fn create_app_salt<S: Filestore, R: CryptoRng + RngCore>(
     fs: &mut S,
     rng: &mut R,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -42,6 +42,8 @@ pub enum AuthRequest {
     DeletePin(request::DeletePin),
     DeleteAllPins(request::DeleteAllPins),
     PinRetries(request::PinRetries),
+    ResetAppKeys(request::ResetAppKeys),
+    ResetAuthData(request::ResetAuthData),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -57,6 +59,8 @@ pub enum AuthReply {
     DeletePin(reply::DeletePin),
     DeleteAllPins(reply::DeleteAllPins),
     PinRetries(reply::PinRetries),
+    ResetAppKeys(reply::ResetAppKeys),
+    ResetAuthData(reply::ResetAuthData),
 }
 
 /// Provides access to the [`AuthExtension`][].
@@ -179,6 +183,16 @@ pub trait AuthClient: ExtensionClient<AuthExtension> {
         info: Message,
     ) -> AuthResult<'_, reply::GetApplicationKey, Self> {
         self.extension(request::GetApplicationKey { info })
+    }
+
+    /// Delete all application keys
+    fn reset_app_keys(&mut self) -> AuthResult<'_, reply::ResetAppKeys, Self> {
+        self.extension(request::ResetAppKeys {})
+    }
+
+    /// Combines [`reset_app_keys`][AuthClient::reset_app_keys] and [`delete_all_pins`](AuthClient::delete_all_pins)
+    fn reset_auth_data(&mut self) -> AuthResult<'_, reply::ResetAuthData, Self> {
+        self.extension(request::ResetAuthData {})
     }
 }
 

--- a/src/extension/reply.rs
+++ b/src/extension/reply.rs
@@ -226,3 +226,42 @@ impl TryFrom<AuthReply> for PinRetries {
         }
     }
 }
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResetAppKeys;
+
+impl From<ResetAppKeys> for AuthReply {
+    fn from(reply: ResetAppKeys) -> Self {
+        Self::ResetAppKeys(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for ResetAppKeys {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::ResetAppKeys(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResetAuthData;
+
+impl From<ResetAuthData> for AuthReply {
+    fn from(reply: ResetAuthData) -> Self {
+        Self::ResetAuthData(reply)
+    }
+}
+
+impl TryFrom<AuthReply> for ResetAuthData {
+    type Error = Error;
+
+    fn try_from(reply: AuthReply) -> Result<Self> {
+        match reply {
+            AuthReply::ResetAuthData(reply) => Ok(reply),
+            _ => Err(Error::InternalError),
+        }
+    }
+}

--- a/src/extension/request.rs
+++ b/src/extension/request.rs
@@ -126,3 +126,21 @@ impl From<PinRetries> for AuthRequest {
         Self::PinRetries(request)
     }
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResetAppKeys;
+
+impl From<ResetAppKeys> for AuthRequest {
+    fn from(request: ResetAppKeys) -> Self {
+        Self::ResetAppKeys(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResetAuthData;
+
+impl From<ResetAuthData> for AuthRequest {
+    fn from(request: ResetAuthData) -> Self {
+        Self::ResetAuthData(request)
+    }
+}


### PR DESCRIPTION
Add `delete_app_keys` and `delete_auth_keys` syscalls.

- `delete_all_pins` now doesn't affect application keys
- `delete_app_keys`: delete all application keys. Getting them again after calling this will not yield the same key
- `delete_auth_data` combines `delete_all_pins` and `delete_app_keys`

This is a breaking change and applications (trussed-secrets) relying on the old `delete_all_pins` behaviour will need to be fixed.