### PR TITLE
Make more items public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ const BACKEND_DIR: &str = "backend-auth";
 )]
 pub struct PinId(u8);
 
-/// Error obtained when trying to parse a [`PinId`][] either through [`PinId::from_path`][] or through the [`FromStr`](core::str::FromStr) implementation.
+/// Error obtained when trying to parse a [`PinId`][] either through [`PinId::from_path`][] or through the [`FromStr`][] implementation.
 #[derive(
     Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize,
 )]
@@ -145,7 +145,7 @@ impl PinId {
             return Err(PinIdFromStrError);
         }
 
-        let id = u8::from_str_radix(&*path, 16).map_err(|_| PinIdFromStrError)?;
+        let id = u8::from_str_radix(path, 16).map_err(|_| PinIdFromStrError)?;
         Ok(PinId(id))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,54 +140,13 @@ impl PinId {
 
     /// Parse a PinId path
     pub fn from_path(path: &str) -> Result<Self, PinIdFromStrError> {
-        let path = path
-            .strip_prefix("pin.")
-            .ok_or(PinIdFromStrError)?
-            .as_bytes();
+        let path = path.strip_prefix("pin.").ok_or(PinIdFromStrError)?;
         if path.len() != 2 {
             return Err(PinIdFromStrError);
         }
 
-        let msb = match path[0] {
-            b'0' => 0x0,
-            b'1' => 0x1,
-            b'2' => 0x2,
-            b'3' => 0x3,
-            b'4' => 0x4,
-            b'5' => 0x5,
-            b'6' => 0x6,
-            b'7' => 0x7,
-            b'8' => 0x8,
-            b'9' => 0x9,
-            b'a' => 0xa,
-            b'b' => 0xb,
-            b'c' => 0xc,
-            b'd' => 0xd,
-            b'e' => 0xe,
-            b'f' => 0xf,
-            _ => return Err(PinIdFromStrError),
-        };
-        let lsb = match path[1] {
-            b'0' => 0x0,
-            b'1' => 0x1,
-            b'2' => 0x2,
-            b'3' => 0x3,
-            b'4' => 0x4,
-            b'5' => 0x5,
-            b'6' => 0x6,
-            b'7' => 0x7,
-            b'8' => 0x8,
-            b'9' => 0x9,
-            b'a' => 0xa,
-            b'b' => 0xb,
-            b'c' => 0xc,
-            b'd' => 0xd,
-            b'e' => 0xe,
-            b'f' => 0xf,
-            _ => return Err(PinIdFromStrError),
-        };
-
-        Ok(PinId((msb << 4) + lsb))
+        let id = u8::from_str_radix(&*path, 16).map_err(|_| PinIdFromStrError)?;
+        Ok(PinId(id))
     }
 }
 
@@ -215,19 +174,14 @@ mod tests {
     use super::PinId;
     use trussed::types::PathBuf;
 
-    quickcheck::quickcheck! {
-        fn test_pin_path(id: u8) -> bool {
-            let actual = PinId(id).path();
-            let expected = PathBuf::from(format!("pin.{id:02x}").as_str());
-            println!("id: {id}, actual: {actual}, expected: {expected}");
-            actual == expected
-        }
-    }
-
     #[test]
     fn pin_id_path() {
         for i in 0..u8::MAX {
-            assert_eq!(Ok(PinId(i)), PinId::from_path(PinId(i).path().as_ref()))
+            assert_eq!(Ok(PinId(i)), PinId::from_path(PinId(i).path().as_ref()));
+            let actual = PinId(i).path();
+            let expected = PathBuf::from(format!("pin.{i:02x}").as_str());
+            println!("id: {i}, actual: {actual}, expected: {expected}");
+            assert_eq!(actual, expected);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,10 @@ const BACKEND_DIR: &str = "backend-auth";
 pub struct PinId(u8);
 
 impl PinId {
-    fn path(&self) -> PathBuf {
+    /// Get the path to the PIN id.
+    ///
+    /// Path are of the form `pin.XX` where `xx` is the hexadecimal representation of the PIN number.
+    pub fn path(&self) -> PathBuf {
         let mut path = [0; 6];
         path[0..4].copy_from_slice(b"pin.");
         path[4..].copy_from_slice(&self.hex());
@@ -118,7 +121,8 @@ impl PinId {
         PathBuf::from(&path)
     }
 
-    fn hex(&self) -> [u8; 2] {
+    /// Get the hex representation of the PIN id
+    pub fn hex(&self) -> [u8; 2] {
         const CHARS: &[u8; 16] = b"0123456789abcdef";
         [
             CHARS[usize::from(self.0 >> 4)],


### PR DESCRIPTION
This PR makes more items public to enable other backends to implement the extension interface.
Motivated by the [se050 backend](https://github.com/Nitrokey/trussed-se050-backend), so this will stay as draft until the backend implements the trussed-auth functionality to avoid having many small PR for similar issues. 