### PR TITLE
Fix changelog entry for #39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased][]
 
 - Use serde(rename) to save space on on the size of stored credentials ([#38][])
+- Remove the `dat` intermediary directory in file storage ([#39][])
 
 [#38]: https://github.com/trussed-dev/trussed-auth/pull/38
+[#39]: https://github.com/trussed-dev/trussed-auth/pull/39
 
 [Unreleased]: https://github.com/trussed-dev/trussed-auth/compare/v0.3.0...HEAD
 
@@ -23,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
-- Remove the `dat` intermediary directory in file storage ([#39][])
 - Add `delete_app_keys` and `delete_auth_keys` syscalls. ([#33][])
 
   - `delete_all_pins` now doesn't affect application keys
@@ -41,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#35]: https://github.com/trussed-dev/trussed-auth/pull/35
 [#36]: https://github.com/trussed-dev/trussed-auth/pull/36
 [#37]: https://github.com/trussed-dev/trussed-auth/pull/37
-[#39]: https://github.com/trussed-dev/trussed-auth/pull/39
 
 ## [0.2.2][] - 2023-04-26
 


### PR DESCRIPTION
The changelog entry for PR #39 ended up in the 0.3.0 section instead of the section for unreleased changes.